### PR TITLE
Fixed setting name. Was 'constellation' but 'modulation' expected.

### DIFF
--- a/src/input/mpegts/linuxdvb/linuxdvb_mux.c
+++ b/src/input/mpegts/linuxdvb/linuxdvb_mux.c
@@ -344,7 +344,7 @@ const idclass_t linuxdvb_mux_dvbs_class =
       MUX_PROP_STR("polarisation", "Polarisation", dvbs, polarity)
     },
     {
-      MUX_PROP_STR("constellation", "Constellation", dvbs, qam)
+      MUX_PROP_STR("modulation", "Modulation", dvbs, qam)
     },
     {
       MUX_PROP_STR("fec", "FEC", dvbs, fec)


### PR DESCRIPTION
Hi Adam,

Found out why I was having trouble with DVB-S in the new dvb-rewrite code.
The setting "Constellation" was being used instead of "Modulation" in dvbs.
That way only modulation was like being hard-coded to QPSK.

Merge (or fix manually).

Regards,
Luis
