### PR TITLE
First committed diseqc message was being sent as a 'retransmition frame'...

### DIFF
--- a/src/input/mpegts/linuxdvb/linuxdvb_switch.c
+++ b/src/input/mpegts/linuxdvb/linuxdvb_switch.c
@@ -144,13 +144,14 @@ linuxdvb_switch_tune
       return -1;
     usleep(25000);
 
+    /* First commited command already sent - repeat flag on */
+    if (sc->ls_diseqc_repeats > 0)
+      r = 1;
+
     /* Committed */
-    if (linuxdvb_diseqc_send(fd, 0xE1, 0x10, 0x38, 1, com))
+    if (linuxdvb_diseqc_send(fd, 0xE0 | r, 0x10, 0x38, 1, com))
       return -1;
     usleep(25000);
-
-    /* repeat flag */
-    r = 1;
   }
 
   /* Tone burst */


### PR DESCRIPTION
Some minor fix.
The frame byte needs to be 0xE0 for the first diseqc message (and 0xE1 for repeats).
I think you assumed it just needs to be 0xE0 for the first message in the bus (independently if it is intended to a committed or uncommitted switch).

It was being sent as 0xE1 in the first message to committed switches.

Tested and working fine on my 2x1 committed switch.
